### PR TITLE
Ansible local provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ rtt min/avg/max/mdev = 4.043/11.891/42.353/15.232 ms
  Congratulations, at this point you have a working 5GC SA setup based on Open5GS + UERANSIM. :+1: 
 
 # Changelog
- * Implemented ansible-local as the main vagrant provisioning option (previously shell provisioners).
+ * Implemented ansible-local as the main vagrant provisioning option (previously shell provisioners). You can still use the shell provisioners instead of the default ansible via: ```VAGRANT_VAGRANTFILE=Vagrantfile.shell vagrant up```
 
 # Optional: Vagrantfile walkthrough 
 TODO

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vagrant configuration for Open5GS & UERANSIM setup
-This repository provides a simple Vagrantfile and the required provisioning shell scripts for creating an Open5GS 5GC &amp; UERANSIM UE/gNB setup with 2 VirtualBox VMs that is pre-configured with quickstart documentation defaults (only for 5GC elements, i.e. AMF, UPF).
+This repository provides a simple Vagrantfile and the required vagrant ansible provisioners for creating an Open5GS 5GC &amp; UERANSIM UE/gNB setup with 2 VirtualBox VMs that is pre-configured with quickstart documentation defaults (only for 5GC elements, i.e. AMF, UPF).
 
 
 # Overview
@@ -179,6 +179,9 @@ rtt min/avg/max/mdev = 4.043/11.891/42.353/15.232 ms
  ```
 
  Congratulations, at this point you have a working 5GC SA setup based on Open5GS + UERANSIM. :+1: 
+
+# Changelog
+ * Implemented ansible-local as the main vagrant provisioning option (previously shell provisioners).
 
 # Optional: Vagrantfile walkthrough 
 TODO

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,7 @@ config.vm.box_check_update = false
         # activate privilege escalation for ansible
         ansible.become = true
         ansible.playbook = "ansible-local-provisioners/bootstrap.yaml"
+        ansible.verbose = true 
     end
 
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,7 @@ config.vm.box_check_update = false
       ansible.playbook = "ansible-local-provisioners/bootstrap.yaml"
       ansible.extra_vars = {
         open5gs_ipv4_addr: OPEN5GS_IPv4_ADDR,
-        ueransim_gnb_ipv4_addr: UERANSIM_IPv4_ADDR
+        ueransim_gnb_ipv4_addr: UERANSIM_IPv4_ADDR,
         open5gs_tac: TAC
       }
       ansible.verbose = true 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,19 @@ config.vm.box_check_update = false
      vb.cpus = "1"
     end
 
+    # Use :ansible_local as the provisioner of guest 
+    ueransim.vm.provision :ansible_local do |ansible|
+      # activate privilege escalation for ansible
+      ansible.become = true
+      ansible.playbook = "ansible-local-provisioners/bootstrap.yaml"
+      ansible.extra_vars = {
+        open5gs_ipv4_addr: OPEN5GS_IPv4_ADDR,
+        ueransim_gnb_ipv4_addr: UERANSIM_IPv4_ADDR
+        open5gs_tac: TAC
+      }
+      ansible.verbose = true 
+    end
+
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,8 @@ config.vm.box_check_update = false
     end
 
     # Use :ansible_local as the provisioner of guest 
+
+    # Open5gs machine provisioner that is run only during initial machine provisioning
     open5gs.vm.provision :ansible_local do |ansible|
         # activate privilege escalation for ansible
         ansible.become = true
@@ -44,6 +46,13 @@ config.vm.box_check_update = false
         }
         ansible.verbose = true 
     end
+
+    # Open5gs machine provisioner for every up/reload
+    open5gs.vm.provision :ansible_local, run: "always"  do |ansible|
+        # activate privilege escalation for ansible
+        ansible.become = true
+        ansible.playbook = "ansible-local-provisioners/always.yaml"
+        end
 
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
 config.vm.box = "bento/ubuntu-18.04"
 config.vm.box_version = "202112.19.0"
 config.vm.box_check_update = false
-config.vm.synced_folder ".", "/vagrant", disabled: true
+
 
 
   # VM #1: OPEN5GS 5G core network (All-in-one)
@@ -61,7 +61,7 @@ config.vm.synced_folder ".", "/vagrant", disabled: true
      vb.memory = "2048"
      vb.cpus = "1"
     end
-    
+
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,10 +44,11 @@ config.vm.box_check_update = false
      vb.cpus = "2"
     end
 
-    # Use :ansible or :ansible_local to
-    # select the provisioner of your choice
-    open5gs.vm.provision :ansible_local do |ansible_local|
-        ansible_local.playbook = "ansible-local-provisioners/bootstrap.yaml"
+    # Use :ansible_local as the provisioner of guest 
+    open5gs.vm.provision :ansible_local do |ansible|
+        # activate privilege escalation for ansible
+        ansible.become = true
+        ansible.playbook = "ansible-local-provisioners/bootstrap.yaml"
     end
 
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,9 +34,6 @@ config.vm.box_check_update = false
   config.vm.define "open5gs" do |open5gs|
     open5gs.vm.network "private_network", ip: OPEN5GS_IPv4_ADDR
     # open5gs.vm.network "public_network"
-
-    # forward port for guest tcp/3000 (Open5GS WebUI) to host 3030
-    open5gs.vm.network "forwarded_port", guest: 3000, host: 3030 
     
     open5gs.vm.provider "virtualbox" do |vb|
      # Customize the amount of cpu & memory on the VM:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ config.vm.box_check_update = false
         ansible.become = true
         ansible.playbook = "ansible-local-provisioners/bootstrap.yaml"
         ansible.extra_vars = {
-          open5gs_ipv4_addr: OPEN5GS_IPv4_ADDR
+          open5gs_ipv4_addr: OPEN5GS_IPv4_ADDR,
           open5gs_tac: TAC
         }
         ansible.verbose = true 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,6 @@ OPEN5GS_IPv4_ADDR = "192.168.56.10"
 UERANSIM_IPv4_ADDR = "192.168.56.11"
 TAC = "2"
 
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
-# Variables
-OPEN5GS_IPv4_ADDR = "192.168.56.10"
-UERANSIM_IPv4_ADDR = "192.168.56.11"
-TAC = "2"
-
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -46,6 +38,10 @@ config.vm.box_check_update = false
         # activate privilege escalation for ansible
         ansible.become = true
         ansible.playbook = "ansible-local-provisioners/bootstrap.yaml"
+        ansible.extra_vars = {
+          open5gs_ipv4_addr: OPEN5GS_IPv4_ADDR
+          open5gs_tac: TAC
+        }
         ansible.verbose = true 
     end
 

--- a/Vagrantfile.shell
+++ b/Vagrantfile.shell
@@ -6,14 +6,6 @@ OPEN5GS_IPv4_ADDR = "192.168.56.10"
 UERANSIM_IPv4_ADDR = "192.168.56.11"
 TAC = "2"
 
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
-# Variables
-OPEN5GS_IPv4_ADDR = "192.168.56.10"
-UERANSIM_IPv4_ADDR = "192.168.56.11"
-TAC = "2"
-
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -44,10 +36,16 @@ config.vm.synced_folder ".", "/vagrant", disabled: true
      vb.cpus = "2"
     end
 
-    # Use :ansible or :ansible_local to
-    # select the provisioner of your choice
-    open5gs.vm.provision :ansible_local do |ansible_local|
-        ansible_local.playbook = "ansible-local-provisioners/bootstrap.yaml"
+    # Open5gs VM bootstrap provisioning with a shell script.
+    open5gs.vm.provision "shell" do |s|
+      s.path   = "shell-provisioners/bootstrap-open5gs.sh"
+      s.args   = [OPEN5GS_IPv4_ADDR, TAC]
+    end
+    
+    # Open5gs VM provisioner for every up/reload
+    open5gs.vm.provision "shell", run: "always"  do |s|
+      s.path   = "shell-provisioners/always-open5gs.sh"
+      s.args   = []
     end
 
   end
@@ -61,7 +59,19 @@ config.vm.synced_folder ".", "/vagrant", disabled: true
      vb.memory = "2048"
      vb.cpus = "1"
     end
-    
+
+    #Enable provisioning with a shell script.
+    ueransim.vm.provision "shell" do |s|
+      s.path   = "shell-provisioners/bootstrap-ueransim.sh"
+      s.args   = [UERANSIM_IPv4_ADDR, OPEN5GS_IPv4_ADDR, TAC]
+    end
+
+    # UERANSIM VM provisioned for every up/reload
+    ueransim.vm.provision "shell", run: "always"  do |s|
+      s.path   = "shell-provisioners/always-ueransim.sh"
+      s.args   = []
+    end
+
   end
 
 end

--- a/ansible-local-provisioners/always.yaml
+++ b/ansible-local-provisioners/always.yaml
@@ -1,0 +1,36 @@
+---
+- name: Open5gs machine playbook that will be executed every up/reload (always)
+  hosts: open5gs
+  gather_facts: False
+  vars:
+  tasks:
+# Enable IP forwarding on the open5gs machine due to UPF
+    - name: Set ip forwarding on in /proc and in the sysctl file and reload if necessary
+      sysctl:
+        name: "{{ item }}"
+        value: '1'
+        sysctl_set: yes
+        state: present
+        reload: yes
+      with_items:
+        - net.ipv4.ip_forward
+        - net.ipv6.conf.all.forwarding
+# Add a NAT rule for the UE to have WAN connectivity over SGi/N6
+    - name: Add iptables (ipv4) rules for ue traffic forwarding over N6 interface
+      ansible.builtin.iptables:
+        ip_version: ipv4
+        chain: POSTROUTING
+        table: nat
+        source: 10.45.0.0/16
+        out_interface: ! ogstun
+        jump: MASQUERADE 
+    - name: Add iptables (ipv6) rules for ue traffic forwarding over N6 interface
+      ansible.builtin.iptables:
+        ip_version: ipv6
+        chain: POSTROUTING
+        table: nat
+        source: 2001:db8:cafe::/48
+        out_interface: ! ogstun
+        jump: MASQUERADE 
+
+

--- a/ansible-local-provisioners/always.yaml
+++ b/ansible-local-provisioners/always.yaml
@@ -15,6 +15,18 @@
       with_items:
         - net.ipv4.ip_forward
         - net.ipv6.conf.all.forwarding
+
+# Flush NAT table rules in case 
+    - name: Iptables flush nat table rules
+      ansible.builtin.iptables:
+        ip_version: '{{ item }}'
+        table: nat
+        chain: POSTROUTING
+        flush: yes
+      with_items:
+        - ipv4
+        - ipv6
+
 # Add a NAT rule for the UE to have WAN connectivity over SGi/N6
     - name: Add iptables (ipv4) rules for ue traffic forwarding over N6 interface
       ansible.builtin.iptables:
@@ -22,7 +34,7 @@
         chain: POSTROUTING
         table: nat
         source: 10.45.0.0/16
-        out_interface: ! ogstun
+        out_interface: "!ogstun"
         jump: MASQUERADE 
     - name: Add iptables (ipv6) rules for ue traffic forwarding over N6 interface
       ansible.builtin.iptables:
@@ -30,7 +42,7 @@
         chain: POSTROUTING
         table: nat
         source: 2001:db8:cafe::/48
-        out_interface: ! ogstun
+        out_interface: "!ogstun"
         jump: MASQUERADE 
 
 

--- a/ansible-local-provisioners/always.yaml
+++ b/ansible-local-provisioners/always.yaml
@@ -45,4 +45,11 @@
         out_interface: "!ogstun"
         jump: MASQUERADE 
 
+- name: UERANSIM machine playbook that will be executed every up/reload (always)
+  hosts: ueransim
+  gather_facts: False
+  vars:
+  tasks:
+    - name: Run open5gs gNB in a screen session with the modified config file
+      shell: screen -S ueransim-gnb -dm  /home/vagrant/UERANSIM/build/nr-gnb -c /home/vagrant/UERANSIM/config/open5gs-gnb.yaml
 

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Open5gs bootstrap playbook
+- name: Open5gs machine playbook that will be played during the first vagrant up (bootstrap)
   hosts: open5gs
   gather_facts: False
   vars:
@@ -70,7 +70,7 @@
   - name: Add a test user in the UDM/UDR database
     shell: open5gs-dbctl add "001010000000001" "465B5CE8B199B49FAA5F0A2EE238A6BC" "E8ED289DEBA952E4283B54E88E6183CA"
     
-- name: UERANSIM bootstrap playbook
+- name: UERANSIM machine playbook that will be played during the first vagrant up (bootstrap)
   hosts: ueransim
   gather_facts: False
   vars:

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -77,14 +77,14 @@
       yq_version: v4.16.2
       yq_binary: yq_linux_amd64
   tasks:
-    - name:  Check connectivity to the Open5gs machine
+    - name:  Wait for connectivity to the open5gs machine
       wait_for:
         host: '{{ open5gs_ipv4_addr|quote }}'
-        port: 2152
+        port: 22
         state: started
         delay: 3
         sleep: 2
-        timeout: 120
+        timeout: 30
     - name: Update repository caches
       apt:
         update_cache: yes

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -109,7 +109,7 @@
     - name: Clone UERANSIM git repository
       ansible.builtin.git:
         repo: 'https://github.com/aligungr/UERANSIM'
-        dest: /home/vagrant/
+        dest: /home/vagrant/UERANSIM/
         clone: yes
     - name: Check if nr-gnb file exists
       stat:

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -2,8 +2,8 @@
 - name: Open5gs bootstrap playbook
   hosts: all
   vars:
-    yq-version: v4.16.2
-    yq-binary: yq_linux_amd64
+    yq_version: v4.16.2
+    yq_binary: yq_linux_amd64
   tasks:
   - name: Add open5gs latest repository from PPA and install its signing key on Ubuntu target
     ansible.builtin.apt_repository:
@@ -38,7 +38,7 @@
     shell: bash /tmp/install-webui
   - name : Download yq tool for YAML editing
     get_url:
-      url: https://github.com/mikefarah/yq/releases/download/{{ yq-version }}/{{ yq-binary }}
+      url: https://github.com/mikefarah/yq/releases/download/{{ yq_version }}/{{ yq_binary }}
       dest: /usr/bin/yq
       mode: +x
       checksum: sha1:57e8bbf5342be07a122abb1513c53f3a178240f9

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -121,7 +121,7 @@
         chdir: /home/vagrant/UERANSIM
         params:
           NUM_THREADS: 2
-      when: not nr_gnb_stat.exists
+      when: not nr_gnb_stat.stat.exists
     - name : Download yq tool for YAML editing
       get_url:
         url: https://github.com/mikefarah/yq/releases/download/{{ yq_version|quote }}/{{ yq_binary|quote }}

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -1,12 +1,10 @@
 ---
 - name: Open5gs bootstrap playbook
-  hosts: all
+  hosts: open5gs
   gather_facts: False
   vars:
     yq_version: v4.16.2
     yq_binary: yq_linux_amd64
-    open5gs_ipv4_addr: 192.168.56.10
-    open5gs_tac: 2
   tasks:
   - name: Add open5gs latest repository from PPA and install its signing key on Ubuntu target
     ansible.builtin.apt_repository:
@@ -72,3 +70,81 @@
   - name: Add a test user in the UDM/UDR database
     shell: open5gs-dbctl add "001010000000001" "465B5CE8B199B49FAA5F0A2EE238A6BC" "E8ED289DEBA952E4283B54E88E6183CA"
     
+- name: UERANSIM bootstrap playbook
+  hosts: ueransim
+  gather_facts: False
+  vars:
+      yq_version: v4.16.2
+      yq_binary: yq_linux_amd64
+  tasks:
+    - name:  Check connectivity to the Open5gs machine
+      wait_for:
+        host: open5gs_ipv4_addr
+        port: 2152
+        state: started
+        delay: 3
+        sleep: 2
+        timeout: 120
+    - name: Update repository caches
+      apt:
+        update_cache: yes
+    - name: Upgrade the OS (apt-get upgrade)
+      apt:
+        upgrade: "yes"
+    - name: Install the required packages for ueransim machine
+      apt:
+        pkg: 
+          - make 
+          - gcc 
+          - g++ 
+          - libsctp-dev 
+          - lksctp-tools
+          - iproute2 
+          - screen
+    - name: Install cmake snap with option -- classic
+      community.general.snap:
+        name: cmake
+        classic: yes
+    - name: Clone UERANSIM git repository
+      ansible.builtin.git:
+        repo: 'https://github.com/aligungr/UERANSIM'
+        dest: /home/vagrant/
+        clone: yes
+    - name: Check if nr-gnb file exists
+      stat:
+        path: /home/vagrant/UERANSIM/build/nr-gnb
+        register: nr_gnb_stat
+    - name: Compile the UERANSIM repo with make
+      make:
+        chdir: /home/vagrant/UERANSIM
+        params:
+          NUM_THREADS: 2
+      when: not nr_gnb_stat.exists
+    - name : Download yq tool for YAML editing
+      get_url:
+        url: https://github.com/mikefarah/yq/releases/download/{{ yq_version|quote }}/{{ yq_binary|quote }}
+        dest: /usr/bin/yq
+        mode: +x
+        checksum: sha1:57e8bbf5342be07a122abb1513c53f3a178240f9
+    - name: Test yq installation
+      shell: yq --version
+      register: yq_exists
+      failed_when: yq_exists.rc != 0
+    - name: Make a backup of the open5gs-gnb config file before editing
+      ansible.builtin.copy:
+        src: /home/vagrant/UERANSIM/config/open5gs-gnb.yaml
+        dest: /home/vagrant/UERANSIM/config/open5gs-gnb.yaml.bkp
+        remote_src: yes
+    - name: Edit open5gs-gnb config file with yq
+      shell:   gNBIP={{ ueransim_gnb_ipv4_addr|quote }} Open5GSIP={{ open5gs_ipv4_addr|quote }} TAC={{ open5gs_tac|quote }}  yq eval -i -I4 ' .mcc="001" | .mnc="01" | .tac=env(TAC) | .linkIp=env(gNBIP) | .ngapIp=env(gNBIP) | .gtpIp=env(gNBIP) | .amfConfigs[0].address=env(Open5GSIP)'  /home/vagrant/UERANSIM/config/open5gs-gnb.yaml
+    - name: Make a backup of the open5gs-ue config file before editing
+      ansible.builtin.copy:
+        src: /home/vagrant/UERANSIM/config/open5gs-ue.yaml
+        dest: /home/vagrant/UERANSIM/config/open5gs-ue.yaml.bkp
+        remote_src: yes
+    - name: Edit open5gs-ue config file with yq
+      shell:   gNBIP={{ ueransim_gnb_ipv4_addr|quote }} yq eval -i -I4 ' .supi="imsi-001010000000001" | .mcc="001" | .mnc="01" | .gnbSearchList[0]=env(gNBIP) ' /home/vagrant/UERANSIM/config/open5gs-ue.yaml
+
+
+
+

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -79,7 +79,7 @@
   tasks:
     - name:  Check connectivity to the Open5gs machine
       wait_for:
-        host: {{ open5gs_ipv4_addr|quote }}
+        host: '{{ open5gs_ipv4_addr|quote }}'
         port: 2152
         state: started
         delay: 3

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -1,6 +1,9 @@
 ---
 - name: Open5gs bootstrap playbook
   hosts: all
+  vars:
+    yq-version: v4.16.2
+    yq-binary: yq_linux_amd64
   tasks:
   - name: Add open5gs latest repository from PPA and install its signing key on Ubuntu target
     ansible.builtin.apt_repository:
@@ -17,11 +20,27 @@
       pkg:
         - open5gs
         - curl
-  - name: Install nodejs ppa repository configuration
-    shell: curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+  - name: Download nodejs-14 ppa source setup script
+    get_url:
+      url: https://deb.nodesource.com/setup_14.x
+      dest: /tmp/setup_14.x
+  - name: Install nodejs-14 ppa repository setup script
+    shell: bash /tmp/setup_14.x
   - name: Install the package "nodejs"
     apt:
       name: nodejs
       update_cache: yes
+  - name: Download open5gs-webui install script 
+    get_url:
+      url: https://open5gs.org/open5gs/assets/webui/install
+      dest: /tmp/install-webui
   - name: Install Open5gs WebUI 
-    shell: curl -fsSL https://open5gs.org/open5gs/assets/webui/install | bash -
+    shell: bash /tmp/install-webui
+  - name : Download yq tool for YAML editing
+    get_url:
+      url: https://github.com/mikefarah/yq/releases/download/{{ yq-version }}/{{ yq-binary }}
+      dest: /usr/bin/yq
+      mode: +x
+      checksum: sha1:57e8bbf5342be07a122abb1513c53f3a178240f9
+  - name: Test yq installation
+    shell: yq --version

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -17,9 +17,7 @@
       name: software-properties-common
   - name: Install the required packages for open5gs setup
     apt:
-      pkg:
-        - open5gs
-        - curl
+      name: open5gs
   - name: Download nodejs-14 ppa source setup script
     get_url:
       url: https://deb.nodesource.com/setup_14.x

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -8,7 +8,7 @@
       update_cache: yes
   - name: Upgrade the OS (apt-get upgrade)
     apt:
-      upgrade: yes
+      upgrade: "yes"
   - name: Install the package "software-properties-common"
     apt:
       name: software-properties-common

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -1,0 +1,27 @@
+---
+- name: Open5gs bootstrap playbook
+  hosts: all
+  tasks:
+  - name: Add open5gs latest repository from PPA and install its signing key on Ubuntu target
+    ansible.builtin.apt_repository:
+      repo: ppa:open5gs/latest
+      update_cache: yes
+  - name: Upgrade the OS (apt-get upgrade)
+    apt:
+      upgrade: yes
+  - name: Install the package "software-properties-common"
+    apt:
+      name: software-properties-common
+  - name: Install the required packages for open5gs setup
+    apt:
+      pkg:
+        - open5gs
+        - curl
+  - name: Install nodejs ppa repository configuration
+    shell: curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+  - name: Install the package "nodejs"
+    apt:
+      name: nodejs
+      update_cache: yes
+  - name: Install Open5gs WebUI 
+    shell: curl -fsSL https://open5gs.org/open5gs/assets/webui/install | bash -

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -111,10 +111,11 @@
         repo: 'https://github.com/aligungr/UERANSIM'
         dest: /home/vagrant/UERANSIM/
         clone: yes
+        update: no
     - name: Check if nr-gnb file exists
       stat:
         path: /home/vagrant/UERANSIM/build/nr-gnb
-        register: nr_gnb_stat
+      register: nr_gnb_stat
     - name: Compile the UERANSIM repo with make
       make:
         chdir: /home/vagrant/UERANSIM

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -101,9 +101,10 @@
           - lksctp-tools
           - iproute2 
           - screen
-    - name: Install cmake snap with option -- classic
-      community.general.snap:
+    - name: Install cmake snap with option --classic
+      snap:
         name: cmake
+        state: present
         classic: yes
     - name: Clone UERANSIM git repository
       ansible.builtin.git:

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -1,9 +1,12 @@
 ---
 - name: Open5gs bootstrap playbook
   hosts: all
+  gather_facts: False
   vars:
     yq_version: v4.16.2
     yq_binary: yq_linux_amd64
+    open5gs_ipv4_addr: 192.168.56.10
+    open5gs_tac: 2
   tasks:
   - name: Add open5gs latest repository from PPA and install its signing key on Ubuntu target
     ansible.builtin.apt_repository:
@@ -36,9 +39,36 @@
     shell: bash /tmp/install-webui
   - name : Download yq tool for YAML editing
     get_url:
-      url: https://github.com/mikefarah/yq/releases/download/{{ yq_version }}/{{ yq_binary }}
+      url: https://github.com/mikefarah/yq/releases/download/{{ yq_version|quote }}/{{ yq_binary|quote }}
       dest: /usr/bin/yq
       mode: +x
       checksum: sha1:57e8bbf5342be07a122abb1513c53f3a178240f9
   - name: Test yq installation
     shell: yq --version
+    register: yq_exists
+    failed_when: yq_exists.rc != 0
+  - name: Make a backup of the AMF config file before editing
+    ansible.builtin.copy:
+      src: /etc/open5gs/amf.yaml
+      dest: /etc/open5gs/amf.yaml.bkp
+      remote_src: yes
+  - name: Edit open5gs AMF config file with yq
+    shell: ip_private={{ open5gs_ipv4_addr|quote }} tac={{ open5gs_tac|quote }} yq eval 'with(.amf; .ngap[0].addr=env(ip_private) | with(.guami[0].plmn_id; .mcc=001 | .mnc=01) | with(.tai[0]; .plmn_id.mcc=001 | .plmn_id.mnc=01 | .tac=env(tac)) | with(.plmn_support[0].plmn_id; .mcc=001 | .mnc=01) )' -i  -I4 /etc/open5gs/amf.yaml
+  - name: Make a backup of the UPF config file before editing
+    ansible.builtin.copy:
+      src: /etc/open5gs/upf.yaml
+      dest: /etc/open5gs/upf.yaml.bkp
+      remote_src: yes
+  - name: Edit open5gs UPF config file with yq
+    shell: ip_private={{ open5gs_ipv4_addr|quote }} yq eval '.upf.gtpu[0].addr=env(ip_private)' -i -I4 /etc/open5gs/upf.yaml
+  - name: Restart systemd AMFD service after config changes
+    ansible.builtin.systemd:
+      state: restarted
+      name: open5gs-amfd
+  - name: Restart systemd UPFD service after config changes
+    ansible.builtin.systemd:
+      state: restarted
+      name: open5gs-upfd
+  - name: Add a test user in the UDM/UDR database
+    shell: open5gs-dbctl add "001010000000001" "465B5CE8B199B49FAA5F0A2EE238A6BC" "E8ED289DEBA952E4283B54E88E6183CA"
+    

--- a/ansible-local-provisioners/bootstrap.yaml
+++ b/ansible-local-provisioners/bootstrap.yaml
@@ -79,7 +79,7 @@
   tasks:
     - name:  Check connectivity to the Open5gs machine
       wait_for:
-        host: open5gs_ipv4_addr
+        host: {{ open5gs_ipv4_addr|quote }}
         port: 2152
         state: started
         delay: 3

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python = auto


### PR DESCRIPTION
This PR implements ansible-local provisioners for configuring vagrant machines instead of using the shell scripts. 

You can still use the shell provisioners instead of the default ansible via: 
```bash
VAGRANT_VAGRANTFILE=Vagrantfile.shell vagrant up
```